### PR TITLE
Added Phosphor

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,6 +4,7 @@ RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y \
 	git make gcc g++ rustc cargo cmake meson pkg-config \
 	curl flex bison clang python3 racket \
+	lsb-release binutils nasm \
 	llvm-12 libclang-common-12-dev llvm-13 libclang-common-13-dev \
 	libfmt-dev zlib1g-dev libblocksruntime-dev libgmp-dev libreadline-dev \
 	libnuma-dev
@@ -17,6 +18,16 @@ RUN \
 RUN \
 	ghcup -v install ghc --isolate /usr/local --force 9.2.2 && \
 	ghcup -v install cabal --isolate /usr/local/bin --force 3.6.2.0
+
+# Install Node.js (the manual way without downloading bash scripts):
+RUN VERSION=node_16.x && \
+    KEYRING=/usr/share/keyrings/nodesource.gpg && \
+	DISTRO="$(lsb_release -s -c)" && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor > "$KEYRING" && \
+	gpg --no-default-keyring --keyring "$KEYRING" --list-keys && \
+	echo "deb [signed-by=$KEYRING] https://deb.nodesource.com/$VERSION $DISTRO main" > /etc/apt/sources.list.d/nodesource.list
+RUN \
+    apt-get update && apt-get install -y nodejs
 
 WORKDIR /app
 RUN mkdir /home/runner && groupadd runner && useradd --home /home/runner -g runner runner

--- a/langs/phosphor/compile.sh
+++ b/langs/phosphor/compile.sh
@@ -1,0 +1,18 @@
+mkdir download
+cd download
+
+# Download the standard library:
+curl -L https://github.com/PhosphorLang/PhosphorStandardLibrary/releases/download/version%2F0.1/phosphorStandardLibrary.tgz -o phosphorStandardLibrary.tgz
+tar zxf phosphorStandardLibrary.tgz
+
+# Download the compiler:
+curl -L https://github.com/PhosphorLang/PhosphorCompiler/releases/download/version%2F0.2.1/phosphor-compiler-0.2.1.tgz -o phosphor-compiler.tgz
+tar zxf phosphor-compiler.tgz
+mv package phosphorCompiler
+
+# Deploy:
+cp -r phosphorStandardLibrary "$DEPLOYDIR"
+cp -r phosphorCompiler "$DEPLOYDIR"
+
+# Sanity confirmation:
+touch "$DEPLOYDIR/.done"

--- a/langs/phosphor/run.sh
+++ b/langs/phosphor/run.sh
@@ -5,6 +5,11 @@ cat > input.ph
 cd phosphorCompiler
 npm start -- -t linuxAmd64 -s ../phosphorStandardLibrary ../input.ph ../output
 
+if [ ! -f ../output ]; then
+    # If no output exists, the compilation did fail and we need to exit with a non-zero exit code:
+    exit 1
+fi
+
 # Execute the programme:
 cd ..
 exec ./output

--- a/langs/phosphor/run.sh
+++ b/langs/phosphor/run.sh
@@ -1,0 +1,10 @@
+# Save code coming from Stdin into a file:
+cat > input.ph
+
+# Compile the code:
+cd phosphorCompiler
+npm start -- -t linuxAmd64 -s ../phosphorStandardLibrary ../input.ph ../output
+
+# Execute the programme:
+cd ..
+exec ./output

--- a/scripts/compile-all.sh
+++ b/scripts/compile-all.sh
@@ -12,6 +12,7 @@ langs='
 	egel
 	gilia
 	osyris
+	phosphor
 	python
 	racket
 	shell


### PR DESCRIPTION
I added the [Phosphor programming language](https://github.com/PhosphorLang).
The version used is the latest release (0.2.1) which I published today.

Note that Node.js, binutils and NASM are needed as dependencies for the compiler to work. The additionally added installation of lsb-release is used for making the node installation platform-agnostic and could theoretically be removed if `DISTRO="$(lsb_release -s -c)"` is replaced with `DISTRO=jammy` (for Ubuntu 22.04) and maintained to match the used image.